### PR TITLE
fix bug in pr #42 day of month

### DIFF
--- a/layouts/_default/notice.html
+++ b/layouts/_default/notice.html
@@ -1,5 +1,5 @@
 <li class="d-md-table mb-4 w-100 border-bottom hover-shadow">
-  <div class="d-md-table-cell text-center p-4 bg-primary text-white mb-4 mb-md-0"><span class="h2 d-block">{{ .PublishDate.Format "06"}}</span> {{ .PublishDate.Format "JAN, 2006"}}</div>
+  <div class="d-md-table-cell text-center p-4 bg-primary text-white mb-4 mb-md-0"><span class="h2 d-block">{{ humanize .PublishDate.Day }}</span> {{ .PublishDate.Format "Jan, 2006"}}</div>
   <div class="d-md-table-cell px-4 vertical-align-middle mb-4 mb-md-0">
     <a href="{{ .Permalink }}" class="h4 mb-3 d-block">{{ .Title }}</a>
     <p class="mb-0">{{ .Summary | truncate 100 }}</p>

--- a/layouts/notice/single.html
+++ b/layouts/notice/single.html
@@ -8,7 +8,7 @@
         <div class="d-flex">
           <div class="text-center mr-4">
             <div class="p-4 bg-primary text-white">
-              <span class="h2 d-block">{{ .PublishDate.Format "06"}}</span> {{ .PublishDate.Format "JAN, 2006"}}
+              <span class="h2 d-block">{{ humanize .PublishDate.Day }}</span> {{ .PublishDate.Format "Jan, 2006"}}
             </div>
           </div>
           <!-- notice content -->


### PR DESCRIPTION
day of the month is still displayed wrong in pull request #42 , please check below image for new working format as per hugo documentation

![image](https://github.com/themefisher/educenter-hugo/assets/6139284/007c1b4c-09ba-4fe3-96be-5bf6fdbbde3e)
